### PR TITLE
scripts.js fixes for default page template

### DIFF
--- a/blocks/header/header.css
+++ b/blocks/header/header.css
@@ -52,7 +52,7 @@ header nav .nav-hamburger {
   display: flex;
   align-items: center;
   justify-self: right;
-    border: 1px solid #ddd;
+    border: 1px solid var(--med-grey);
     border-radius: 4px;
     padding: 5px 10px;
     opacity: .6;
@@ -167,7 +167,7 @@ header nav .nav-sections ul > li {
     position: relative;
     display: block;
     padding: 10px 0;
-    color: #777;
+    color: var(--med-grey);
     font-size: var(--heading-font-size-s);
     width: calc(100% - 50px);
     font-family: Roboto, 'Roboto Fallback', sans-serif;

--- a/blocks/hero/hero.css
+++ b/blocks/hero/hero.css
@@ -1,35 +1,40 @@
-.hero-container .hero-wrapper {
-  max-width: unset;
-  padding: 0;
-}
+.hero-container {
+  height: 200px;
 
-.hero {
-  padding: 40px 0;
-  height: 120px;
+  .hero-wrapper {
+    max-width: unset;
+    padding: 0;
+  }
+
+  .hero {
+    padding: 40px 0;
+    height: 120px;
 
     figure {
-        margin-inline-start: 24px;
+      margin-inline-start: 24px;
     }
 
     .hero-image {
-        position: absolute;
-        z-index: -1;
-        inset: 0;
-        object-fit: cover;
-        box-sizing: border-box;
-        max-height: 250px;
+      position: absolute;
+      z-index: -1;
+      inset: 0;
+      object-fit: cover;
+      box-sizing: border-box;
+      max-height: 250px;
 
-        img {
-            object-fit: cover;
-            width: 100%;
-            height: 100%;
-            object-position: top;
-        }
+      img {
+        object-fit: cover;
+        width: 100%;
+        height: 100%;
+        object-position: top;
+      }
     }
 
     .ocio-logo {
-        height: 107px;
+      height: 107px;
+      width: auto;
     }
+  }
 }
 
 @media (width >= 1200px) {

--- a/blocks/subnav/subnav.css
+++ b/blocks/subnav/subnav.css
@@ -3,8 +3,6 @@
   grid-template-columns: 1fr;
   grid-auto-rows: auto;
   gap: 40px;
-  max-width: 1000px;
-  margin: auto auto 40px;
 }
 
 .subnav-group-container .grouped-content-container .grouped-content {
@@ -24,11 +22,11 @@
 .subnav-group-container .grouped-content-container .grouped-content p:first-child {
   font-weight: bold;
   font-size: 22.4px;
-  color: #9B9B9B;
+  color: var(--alt-link-hover-color);
 }
 
 .subnav-group-container .grouped-content-container .grouped-content p:first-child a {
-  color: #363636;
+  color: var(--alt-link-color);
   text-decoration: underline;
   font-weight: bold;
   font-size: 22.4px;
@@ -36,7 +34,7 @@
 
 .subnav-group-container .grouped-content-container .grouped-content p a:hover {
   text-decoration: none;
-  color: #9B9B9B;
+  color: var(--alt-link-hover-color);
 }
 
 .grouped-content-container .grouped-content.blue {
@@ -52,8 +50,13 @@
 }
 
 @media (width >= 900px) {
-  .subnav-wrapper .subnav .subnav-group-container .grouped-content-container {
-    grid-template-columns: repeat(3, 1fr);
+  .subnav-wrapper .subnav {
+    max-width: 950px;
+    margin: auto auto 40px 17%;
+
+    .subnav-group-container .grouped-content-container {
+      grid-template-columns: repeat(3, 1fr);
+    }
   }
 }
 

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -44,6 +44,7 @@ function buildHeroBlock(main) {
     picture.classList.add('hero-image');
     const logo = createOptimizedPicture(logoUrl, 'Nebraska - Good Life. Great Opportunity', true);
     logo.querySelector('img').setAttribute('height', '107px');
+    logo.querySelector('img').setAttribute('width', 'auto');
     const logoLink = document.createElement('a');
     logoLink.href = '/';
     logoLink.append(logo);

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -258,8 +258,6 @@ async function buildDefaultTemplate() {
   if (template !== 'home') {
     const main = document.querySelector('main');
     const h1 = main.querySelector('h1:first-of-type');
-    const subnav = main.querySelector(':scope div.subnav-wrapper');
-    let wrapperSection = main.querySelector('.main-content');
     const contentSection = main.querySelector(':scope > .section.hero-container+.section') || main.querySelector(':scope > .section');
     // create a lower wrapper div to place aside and content
     const pageContentWrapper = document.createElement('div');

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -172,7 +172,7 @@ export async function loadFragment(path) {
     }
     const resp = await fetch(`${path}.plain.html`);
     if (resp.ok) {
-      const main = document.createElement('main');
+      const main = document.createElement('div');
       main.innerHTML = await resp.text();
       fragmentCache.set(path, main);
       return main;
@@ -208,7 +208,7 @@ async function buildBreadcrumbs() {
   // if breadcrumb-title is "false" in metadata, return an empty div
   if (breadcrumbMetadata !== 'False' && breadcrumbMetadata !== 'false') {
     // Even if breadcrumbs are disabled, we need an empty div to keep the layout consistent
-    outerSection.className = 'breadcrumbs-outer';
+    outerSection.className = 'breadcrumbs-outer wrapper';
     const container = document.createElement('div');
     container.className = 'section breadcrumbs-container';
     const breadcrumb = document.createElement('nav');
@@ -239,66 +239,48 @@ async function buildBreadcrumbs() {
 }
 /* END BREADCRUMBS */
 
+function buildLinksOfInterest() {
+  const aside = document.createElement('aside');
+  aside.classList.add('content-aside');
+  loadFragment('/fragments/links-of-interest').then((fragment) => {
+    aside.append(fragment);
+    decoratePicturesWithLinks(aside);
+  });
+  return aside;
+}
+
 /**
  * wraps main content with breadcrumbs, subnav, and aside.
  */
 
-async function wrapMainContent() {
+async function buildDefaultTemplate() {
   const template = getMetadata('template');
   if (template !== 'home') {
     const main = document.querySelector('main');
-    const breadcrumbs = await buildBreadcrumbs();
-    const sections = main.querySelectorAll(':scope > div.section');
     const h1 = main.querySelector('h1:first-of-type');
     const subnav = main.querySelector(':scope div.subnav-wrapper');
     let wrapperSection = main.querySelector('.main-content');
+    const contentSection = main.querySelector(':scope > .section.hero-container+.section') || main.querySelector(':scope > .section');
+    // create a lower wrapper div to place aside and content
+    const pageContentWrapper = document.createElement('div');
+    pageContentWrapper.className = 'page-details-wrapper';
+    // aside and content wrappers will be appended to this wrapper
+    const asideWrapper = document.createElement('div');
+    asideWrapper.className = 'aside-details-wrapper';
+    const contentWrapper = document.createElement('div');
+    contentWrapper.className = 'content-details-wrapper';
 
-    if (!wrapperSection && sections.length > 0) {
-      wrapperSection = document.createElement('div');
-      wrapperSection.classList.add('main-content');
-      const fragment = document.createDocumentFragment();
-      const heroContainer = main.querySelector('.hero-container:first-of-type');
+    // move all divs into content wrapper div
+    contentSection.querySelectorAll('div[class*="wrapper"]:not(.subnav-wrapper)').forEach((div) => {
+      contentWrapper.append(div);
+    });
+    asideWrapper.prepend(await buildLinksOfInterest());
+    pageContentWrapper.append(asideWrapper, contentWrapper);
+    contentSection.append(pageContentWrapper);
 
-      if (heroContainer) {
-        let nextSibling = heroContainer.nextElementSibling;
-        while (nextSibling) {
-          const currentSibling = nextSibling;
-          nextSibling = nextSibling.nextElementSibling;
-          fragment.appendChild(currentSibling);
-        }
-        wrapperSection.appendChild(fragment);
-        heroContainer.after(breadcrumbs);
-        if (subnav) {
-          breadcrumbs.after(subnav);
-          subnav.after(wrapperSection);
-        } else {
-          breadcrumbs.after(wrapperSection);
-        }
-        breadcrumbs.prepend(h1);
-      } else {
-        sections.forEach((section) => {
-          fragment.appendChild(section);
-        });
-        wrapperSection.appendChild(fragment);
-        main.prepend(breadcrumbs);
-        breadcrumbs.prepend(h1);
-        if (subnav) {
-          breadcrumbs.after(subnav);
-        }
-        main.append(wrapperSection);
-      }
-    }
-
-    let aside = wrapperSection.querySelector('.content-aside');
-    if (!aside) {
-      aside = document.createElement('aside');
-      aside.classList.add('content-aside');
-      loadFragment('/fragments/links-of-interest').then((fragment) => {
-        aside.append(fragment);
-        decoratePicturesWithLinks(aside);
-      });
-      wrapperSection.prepend(aside);
-    }
+    contentSection.before(h1, await buildBreadcrumbs());
+    const emptyDivs = main.querySelectorAll('div:empty');
+    emptyDivs.forEach((div) => div.remove());
   }
 }
 
@@ -379,7 +361,6 @@ export function decorateMain(main) {
   decorateBlocks(main);
   decorateStyledSections(main);
   createObserver();
-  wrapMainContent();
   decoratePicturesWithLinks(main);
   buildYoutubeBlocks(main);
 }
@@ -400,6 +381,7 @@ async function loadTemplate(main) {
         `${window.hlx.codeBasePath}/templates/${template}/${template}.css`,
       );
     }
+    buildDefaultTemplate(main);
   } catch (err) {
     // eslint-disable-next-line no-console
     console.error(`Failed to load template with error : ${err}`);

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -43,6 +43,7 @@ function buildHeroBlock(main) {
     const picture = createOptimizedPicture(pictureUrl, 'Hero image', true, [{ media: '(min-width: 600px)', width: '2000' }, { width: '750' }]);
     picture.classList.add('hero-image');
     const logo = createOptimizedPicture(logoUrl, 'Nebraska - Good Life. Great Opportunity', true);
+    logo.querySelector('img').setAttribute('height', '107px');
     const logoLink = document.createElement('a');
     logoLink.href = '/';
     logoLink.append(logo);

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -15,7 +15,8 @@
   --dark-color: #505050;
   --text-color: #131313;
   --footer-color: #39454b;
-  --footer-text-color: #b9babb7f;
+  --footer-text-color: #b1b1b1; /* accessible contrast */
+  --med-grey: #757575; /* accessible contrast against white */
   --line-color: #eee;
   --font-style: normal;
   --link-color: #3b63fb;
@@ -33,7 +34,7 @@
   --heading-font-size-m: 18px;
   --heading-font-size-s: 16px;
   --heading-font-size-xs: 12px;
-  --nav-height: 50px;
+  --nav-height: 50px; /* rgb(117 117 117) */
   --button-font-size: 18px;
 }
 

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -22,22 +22,19 @@
   --link-hover-color: #1d3ecf;
   --alt-link-color: #363636;
   --alt-link-hover-color: #9B9B9B;
-  --body-font-family: "Source Sans Pro", "Source Sans Pro Fallback",
-    "sans-serif";
-  --heading-font-family: "Source Sans Pro", "Source Sans Pro Fallback",
-    "sans-serif";
+  --body-font-family: "Roboto", "Roboto Fallback", "sans-serif";
+  --heading-font-family: "Roboto", "Roboto Fallback", "sans-serif";
   --body-font-size-m: 18px;
   --body-font-size-s: 14px;
   --body-font-size-xs: 12px;
   --heading-font-size-xxl: 36px;
-  --heading-font-size-xl: 39px;
+  --heading-font-size-xl: 28px;
   --heading-font-size-l: 26px;
   --heading-font-size-m: 18px;
   --heading-font-size-s: 16px;
   --heading-font-size-xs: 12px;
   --nav-height: 50px;
   --button-font-size: 18px;
-  --button-font-family: "Roboto", "Roboto Fallback", "sans-serif";
 }
 
 /* fallback fonts */
@@ -91,7 +88,7 @@
     --body-font-size-s: 14px;
     --body-font-size-xs: 12px;
     --heading-font-size-xxl: 36px;
-    --heading-font-size-xl: 39px;
+    --heading-font-size-xl: 28px;
     --heading-font-size-l: 26px;
     --heading-font-size-m: 18px;
     --heading-font-size-s: 16px;
@@ -188,8 +185,36 @@ pre {
   white-space: pre;
 }
 
-.center {
+/* use Word or Gdoc table alignment to position cell contents in most blocks */
+.center, [data-align="center"] {
   text-align: center;
+  background-position-x: center;
+}
+
+[data-valign="bottom"] {
+  align-content: end;
+  background-position-y: bottom;
+}
+
+[data-valign="middle"] {
+  align-content: center;
+  background-position-y: center;
+}
+
+[data-valign="top"] {
+  align-content: start;
+  background-position-y: top;
+}
+
+[data-align="right"] {
+  text-align: right;
+  background-position-x: right;
+}
+
+/* align="left" isn't added to data attributes so use justify instead */
+[data-align="left"], [data-align="justify"] {
+  text-align: left;
+  background-position-x: left;
 }
 
 main > div {
@@ -224,7 +249,6 @@ a:hover {
   margin-bottom: 10px;
   font-weight: bold;
   font-size: var(--button-font-size);
-  font-family: var(--button-font-family);
 }
 
 button:disabled,
@@ -258,7 +282,7 @@ main img {
 }
 
 main > h1 {
-  max-width: 1200px;
+  max-width: 1140px;
   margin: auto;
   padding: 20px 16px 10px;
 }
@@ -273,7 +297,7 @@ main > .section {
 }
 
 main > .section > div {
-  max-width: 1200px;
+  max-width: 1140px;
   margin: auto;
   padding: 0 24px;
 }
@@ -286,18 +310,32 @@ main > .section:first-of-type {
   margin: 80px auto;
 }
 
+main .section.light,
+main .section.highlight {
+  background-color: var(--light-color);
+  margin: 0;
+  padding: 40px 0;
+}
+
+/* dividers */
+p:has(code.divider) {
+  border-bottom: 1px solid #eee;
+  margin-top: 2em;
+  padding-top: 2em;
+  margin-bottom: 0;
+}
+
 /* BREADCRUMBS */
 .breadcrumbs-outer {
   margin: 0 auto 12px;
   padding: 0 16px 9px;
   border-bottom: 1px solid var(--line-color);
-  max-width: 1200px;
+  max-width: 1140px;
 
   .breadcrumbs,
   .breadcrumbs a {
     background-color: transparent;
     font-weight: bold;
-    font-family: var(--button-font-family);
     font-size: var(--body-font-size-s);
     color: var(--text-color);
     margin: 0;
@@ -322,18 +360,25 @@ main .aside-details-wrapper {
     }
   }
 
-  .columns > div {
+  .columns > div { /* specific to aside icons */
     display: flex;
     padding: 10px 0;
+    flex-direction: row;
 
     > div {
       margin-right: 10px;
+      flex: unset;
+    }
+
+    img {
+      width: unset;
     }
   }
 
   .content-aside {
     h1 {
       margin-top: 0;
+      font-size: var(--heading-font-size-xl);
       font-weight: normal;
       border-bottom: 1px solid var(--line-color);
     }
@@ -354,12 +399,16 @@ main .aside-details-wrapper {
   .section > div.page-details-wrapper {
     margin: 80px auto;
     display: flex;
-    max-width: 1200px;
-    gap: 8%;
+    max-width: 1140px;
     padding: 0 16px;
 
     .aside-details-wrapper {
       min-width: 200px;
+    }
+
+    .content-details-wrapper {
+      width: 59%;
+      margin-left: 14%;
     }
   }
 
@@ -370,20 +419,4 @@ main .aside-details-wrapper {
   .subnav-wrapper {
     margin-left: 12%;
   }
-}
-
-/* section metadata */
-main .section.light,
-main .section.highlight {
-  background-color: var(--light-color);
-  margin: 0;
-  padding: 40px 0;
-}
-
-/* dividers */
-p:has(code.divider) {
-  border-bottom: 1px solid #eee;
-  margin-top: 2em;
-  padding-top: 2em;
-  margin-bottom: 0;
 }

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -257,6 +257,12 @@ main img {
   width: 100%;
 }
 
+main > h1 {
+  max-width: 1200px;
+  margin: auto;
+  padding: 20px 16px 10px;
+}
+
 /* sections */
 main > .section {
   margin: 40px 0;
@@ -276,13 +282,16 @@ main > .section:first-of-type {
   margin-top: 0;
 }
 
+.section > div.page-details-wrapper {
+  margin: 80px auto;
+}
+
 /* BREADCRUMBS */
 .breadcrumbs-outer {
-  padding-bottom: 12px;
-  border-bottom: 1px solid var(--light-color);
+  margin: 0 auto 12px;
+  padding: 0 16px 9px;
+  border-bottom: 1px solid var(--line-color);
   max-width: 1200px;
-  margin: 12px 16px;
-  min-height: 83px;
 
   .breadcrumbs,
   .breadcrumbs a {
@@ -299,31 +308,63 @@ main > .section:first-of-type {
   }
 }
 
-.main-content .aside {
-  min-height: 350px;
+main .aside-details-wrapper {
+  min-height: 345px;
+  max-width: 285px;
+  margin-top: 24px;
+
+  a { /* stylelint-disable-line */
+    text-decoration: underline;
+    color: var(--alt-link-color);
+
+    &:hover {
+      color: var(--alt-link-hover-color);
+    }
+  }
+
+  .columns > div {
+    display: flex;
+    padding: 10px 0;
+
+    > div {
+      margin-right: 10px;
+    }
+  }
+
+  .content-aside {
+    h1 {
+      margin-top: 0;
+      font-weight: normal;
+      border-bottom: 1px solid var(--line-color);
+    }
+
+    ul {
+      list-style-type: none;
+      padding-inline-start: 0;
+
+      li {
+        border-bottom: 1px solid var(--line-color);
+        padding: 5px 0;
+      }
+    }
+  }
 }
 
 @media (width >= 900px) {
-  .main-content {
+  .section > div.page-details-wrapper {
     margin: 80px auto;
     display: flex;
     max-width: 1200px;
     gap: 8%;
     padding: 0 16px;
 
-    aside {
+    .aside-details-wrapper {
       min-width: 200px;
-      min-height: unset;
     }
   }
 
   main > .section > div {
     padding: 0 32px;
-  }
-
-  .breadcrumbs-outer {
-    margin: 0 auto 12px;
-    padding: 0 16px 12px;
   }
 
   .subnav-wrapper {

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -16,9 +16,12 @@
   --text-color: #131313;
   --footer-color: #39454b;
   --footer-text-color: #b9babb7f;
+  --line-color: #eee;
   --font-style: normal;
   --link-color: #3b63fb;
   --link-hover-color: #1d3ecf;
+  --alt-link-color: #363636;
+  --alt-link-hover-color: #9B9B9B;
   --body-font-family: "Source Sans Pro", "Source Sans Pro Fallback",
     "sans-serif";
   --heading-font-family: "Source Sans Pro", "Source Sans Pro Fallback",


### PR DESCRIPTION
This PR was a refactor of how the default template is assembled. Previously, the Aside (with Links of Interest) were causing the main content to move as page was loading (pushing down in mobile, or to the right in desktop).

The Google page scan is still seeing higher CLS for pages without a subnav; however the Google manual pagespeed and  Debugbear scans gives a 100. 
https://pagespeed.web.dev/analysis/https-44-asidecls--cio-nebraska--aemdemos-aem-page-news-reports/7mhpy28u26?form_factor=desktop
https://www.debugbear.com/test/website-speed/rK2iQxjk/overview#


Fix #44 

Test URLs:
**with no subnav:**

Before: https://main--cio-nebraska--aemdemos.aem.page/rates
After: https://44-asidecls--cio-nebraska--aemdemos.aem.page/rates

Before: https://main--cio-nebraska--aemdemos.aem.page/news/reports
After: https://44-asidecls--cio-nebraska--aemdemos.aem.page/news/reports

**With subnav:**

Before: https://main--cio-nebraska--aemdemos.aem.page/news
After: https://44-asidecls--cio-nebraska--aemdemos.aem.page/news

**With subnav and a columns block in the content**

Before: https://final--cio-nebraska--aemdemos.aem.page/servicedesk
After: https://44-asidecls--cio-nebraska--aemdemos.aem.page/servicedesk

**Without hero, and with a block in the content**

Before: https://main--cio-nebraska--aemdemos.aem.page/drafts/chelms/news
After: https://44-asidecls--cio-nebraska--aemdemos.aem.page/drafts/chelms/news

