### PR TITLE
change hero logo + left icons to svg

### DIFF
--- a/aemedge/scripts/aem.js
+++ b/aemedge/scripts/aem.js
@@ -458,7 +458,7 @@ function decorateIcon(span, prefix = '', alt = '') {
   const img = document.createElement('img');
   img.dataset.iconName = iconName;
   img.src = `${window.hlx.codeBasePath}${prefix}/icons/${iconName}.svg`;
-  img.alt = alt;
+  img.alt = alt || iconName;
   img.loading = 'lazy';
   span.append(img);
 }

--- a/aemedge/scripts/scripts.js
+++ b/aemedge/scripts/scripts.js
@@ -27,7 +27,7 @@ const TEMPLATE_META = 'template';
  */
 function buildHeroBlock(main) {
   const h1 = main.querySelector('h1');
-  const logoUrl = 'https://main--cio-nebraska--aemdemos.aem.live/cio-ne-logo.png';
+  const logoUrl = 'https://main--cio-nebraska--aemdemos.aem.page/aemedge/icons/ocio-logo-white.svg';
   let pictureUrl = getMetadata('og:image') || ''; // Add default empty string
 
   // Early return if we don't have an H1
@@ -49,8 +49,6 @@ function buildHeroBlock(main) {
   const picture = createOptimizedPicture(pictureUrl, 'Hero image', true, [{ media: '(min-width: 600px)', width: '2000' }, { width: '750' }]);
   picture.classList.add('hero-image');
   const logo = createOptimizedPicture(logoUrl, 'Nebraska - Good Life. Great Opportunity', true);
-  logo.querySelector('img').setAttribute('height', '107px');
-  logo.querySelector('img').setAttribute('width', 'auto');
   const logoLink = document.createElement('a');
   logoLink.href = '/';
   logoLink.append(logo);

--- a/aemedge/scripts/scripts.js
+++ b/aemedge/scripts/scripts.js
@@ -262,6 +262,7 @@ function buildLinksOfInterest() {
   loadFragment('/aemedge/fragments/links-of-interest').then((fragment) => {
     aside.append(fragment);
     decoratePicturesWithLinks(aside);
+    decorateIcons(aside);
   });
   return aside;
 }

--- a/aemedge/styles/styles.css
+++ b/aemedge/styles/styles.css
@@ -279,7 +279,7 @@ main img {
   &.icon-twitter, &.icon-facebook {
     height: 34px;
     width: 34px;
-    opacity: 35%;
+    opacity: 0.35;
   }
 }
 

--- a/aemedge/styles/styles.css
+++ b/aemedge/styles/styles.css
@@ -275,6 +275,12 @@ main img {
   display: inline-block;
   height: 24px;
   width: 24px;
+
+  &.icon-twitter, &.icon-facebook {
+    height: 34px;
+    width: 34px;
+    opacity: 35%;
+  }
 }
 
 .icon img {


### PR DESCRIPTION
Using an svg so we don't need a logo 1.5x the display size for the Google pagespeed best practice test.

Fix #288

Test URLs:
- Before: https://main--cio-nebraska--aemdemos.aem.page/news
- After: https://228-herologo--cio-nebraska--aemdemos.aem.page/news

- Before: https://main--cio-nebraska--aemdemos.aem.page/rates
- After: https://228-herologo--cio-nebraska--aemdemos.aem.page/rates

Accessibility and best practices should be 100 now.