### PR TITLE
Youtube red arrow doesn't hide when playing vid #244

### DIFF
--- a/aemedge/blocks/embed/lite-yt-embed/lite-yt-embed.js
+++ b/aemedge/blocks/embed/lite-yt-embed/lite-yt-embed.js
@@ -140,6 +140,7 @@ class LiteYTEmbed extends HTMLElement {
   async addIframe() {
     if (this.classList.contains('lyt-activated')) return;
     this.classList.add('lyt-activated');
+    this.firstChild.hidden = true; // Hide the play button
 
     const params = new URLSearchParams(this.getAttribute('params') || []);
     params.append('autoplay', '1');


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #244 

Test URLs:
- Before: https://main--cio-nebraska--aemdemos.aem.page/about/about-ocio
- After: https://244-youtube-arrow--cio-nebraska--aemdemos.aem.live/about/about-ocio
