### PR TITLE
fix breadcrumbs, undo some bolding there + in cards

### DIFF
--- a/aemedge/blocks/cards/cards.css
+++ b/aemedge/blocks/cards/cards.css
@@ -1,61 +1,73 @@
-.cards-wrapper .cards .cards-group-container .grouped-content-container {
-  display: grid;
-  grid-template-columns: 1fr;
-  grid-auto-rows: auto;
-  gap: 40px;
-}
+.cards-wrapper {
+  .cards {
+    .cards-group-container {
+      .grouped-content-container {
+        display: grid;
+        grid-template-columns: 1fr;
+        grid-auto-rows: auto;
+        gap: 40px;
 
-.cards-group-container .grouped-content-container .grouped-content {
-  border-left: 7px solid;
-  padding-left: 15px;
-  border-left-color: unset;
-  box-sizing: border-box;
-}
+        .grouped-content {
+          border-left: 7px solid;
+          padding-left: 15px;
+          border-left-color: unset;
+          box-sizing: border-box;
 
-.cards-group-container .grouped-content-container .grouped-content p {
-  margin-top: 0;
-  font-family: Roboto, 'Roboto Fallback', sans-serif;
-  font-size: 14.4px;
-  color: #696969;
-}
+          .button-container {
+            font-weight: unset;
+          }
 
-.cards-group-container .grouped-content-container .grouped-content p:first-child {
-  font-weight: bold;
-  font-size: 22.4px;
-  color: var(--alt-link-hover-color);
-}
+          p {
+            margin-top: 0;
+            font-family: Roboto, 'Roboto Fallback', sans-serif;
+            font-size: 14.4px;
+            color: #696969;
 
-.cards-group-container .grouped-content-container .grouped-content p:first-child a {
-  color: var(--alt-link-color);
-  text-decoration: underline;
-  font-weight: bold;
-  font-size: 22.4px;
-}
+            &:first-child {
+              font-size: 22.4px;
+              color: var(--alt-link-hover-color);
 
-.cards-group-container .grouped-content-container .grouped-content p a:hover {
-  text-decoration: none;
-  color: var(--alt-link-hover-color);
-}
+              a {
+                color: var(--alt-link-color);
+                text-decoration: underline;
+                font-size: 22.4px;
+              }
+            }
+          }
 
-.grouped-content-container .grouped-content.blue {
-  border-left-color: #00607F;
-}
+          p a:hover {
+            text-decoration: none;
+            color: var(--alt-link-hover-color);
+          }
 
-.grouped-content-container .grouped-content.red {
-  border-left-color: #BB1F53;
-}
+          &.blue {
+            border-left-color: #00607F;
+          }
 
-.grouped-content-container .grouped-content.grey {
-    border-left-color: #B9C8D3;
+          &.red {
+            border-left-color: #BB1F53;
+          }
+
+          &.grey {
+            border-left-color: #B9C8D3;
+          }
+        }
+      }
+    }
+  }
 }
 
 @media (width >= 900px) {
-  .cards-wrapper .cards {
-    max-width: 950px;
-    margin: auto auto 40px 17%;
+  .cards-wrapper {
+    .cards {
+      max-width: 950px;
+      margin: auto auto 40px 17%;
 
-    .cards-group-container .grouped-content-container {
-      grid-template-columns: repeat(3, 1fr);
+      .cards-group-container {
+        .grouped-content-container {
+          grid-template-columns: repeat(3, 1fr);
+        }
+      }
     }
   }
 }

--- a/aemedge/scripts/scripts.js
+++ b/aemedge/scripts/scripts.js
@@ -202,16 +202,13 @@ export async function loadFragment(path) {
 const getFragmentPath = (path) => {
   let fragmentPath;
   switch (true) {
-    case path.includes('/news/'):
+    case path.startsWith('/news/'):
       fragmentPath = '/aemedge/fragments/breadcrumbs-news';
       break;
-    case path.includes('/contact/'):
-      fragmentPath = '/aemedge/fragments/breadcrumbs-contact';
-      break;
-    case path.includes('/servicedesk/'):
+    case path.startsWith('/servicedesk/'):
       fragmentPath = '/aemedge/fragments/breadcrumbs-servicedesk';
       break;
-    case path.includes('/about/'):
+    case path.startsWith('/about/'):
       fragmentPath = '/aemedge/fragments/breadcrumbs-about';
       break;
     default:
@@ -222,7 +219,7 @@ const getFragmentPath = (path) => {
 
 async function buildBreadcrumbs() {
   const outerSection = document.createElement('div');
-  const breadcrumbMetadata = getMetadata('breadcrumb-title') || getMetadata('og:title') || '';
+  const breadcrumbMetadata = getMetadata('breadcrumb-title') || '';
   // if breadcrumb-title is "false" in metadata, return an empty div
   if (breadcrumbMetadata !== 'False' && breadcrumbMetadata !== 'false') {
     // Even if breadcrumbs are disabled, we need an empty div to keep the layout consistent
@@ -240,7 +237,9 @@ async function buildBreadcrumbs() {
       const breadcrumbLinks = fragment.querySelectorAll('a');
       breadcrumbLinks.forEach((link, index) => {
         breadcrumb.appendChild(link);
-        if (index < breadcrumbLinks.length) {
+        // Only add separator if it's not the last link OR there is breadcrumb metadata
+        if (index < breadcrumbLinks.length - 1
+          || (breadcrumbMetadata && breadcrumbMetadata.trim())) {
           const separator = document.createElement('span');
           separator.className = 'breadcrumb-separator';
           separator.textContent = ' / ';

--- a/aemedge/styles/styles.css
+++ b/aemedge/styles/styles.css
@@ -347,7 +347,6 @@ p:has(code.divider) {
   .breadcrumbs,
   .breadcrumbs a {
     background-color: transparent;
-    font-weight: bold;
     font-size: var(--body-font-size-s);
     color: var(--text-color);
     margin: 0;


### PR DESCRIPTION
Fixed these things:
- breadcrumbs no longer bold
- breadcrumbs match on "startsWith" instead of "contains"
- if page has an empty value for 'breadcrumb title', no trailing slash separator is added (see my post about it in Slack `https://adobedx.slack.com/archives/C02THE1J4TW/p1742037493392889`)
- unbolded 'cards' titles and breadcrumbs so they match the original site
- also refactored the CSS for cards to have a nested layout to make it easier to read  (see my post about it in Slack `https://adobedx.slack.com/archives/C02THE1J4TW/p1742038066765209`)

Fix #252 

Test URLs:
- Before: https://main--cio-nebraska--aemdemos.aem.live/news/
- After: https://252-breadcrumb--cio-nebraska--aemdemos.aem.live/news/
