### PR TITLE
256 subnavtargets

### DIFF
--- a/aemedge/blocks/header/header.css
+++ b/aemedge/blocks/header/header.css
@@ -201,20 +201,16 @@ header nav .nav-sections .default-content-wrapper > ul > li[aria-expanded='true'
     padding: 5px;
     font-size: var(--body-font-size-s);
     margin: 0 0 0 10px;
+    width: 100%;
 }
 
+/* stylelint-disable-next-line no-descending-specificity */
 header nav .nav-sections ul > li > ul > li > a {
   display: block;
   width: 100%;
   height: 100%;
   box-sizing:content-box;
-  text-decoration: none;
   color: inherit;
-}
-
-header nav a:any-link:hover {
-  color: #333;
-  text-decoration: none;
 }
 
   @media (width >= 900px) {
@@ -311,7 +307,8 @@ header nav a:any-link:hover {
 
         > li {
           margin: 0;
-          padding-left:10px;
+          padding-left: 10px;
+          width: unset;
         }
 
         > a {

--- a/aemedge/blocks/header/header.css
+++ b/aemedge/blocks/header/header.css
@@ -170,15 +170,6 @@ header nav .nav-sections ul > li {
   margin: 10px;
 }
 
-header nav .nav-sections ul > li > ul > li > a {
-  display: block;
-  width: 100%;
-  height: 100%;
-  box-sizing:content-box;
-  text-decoration: none;
-  color: inherit;
-}
-
 header nav .nav-sections .default-content-wrapper ul > li > ul {
      display: none;
      position: relative;
@@ -210,6 +201,15 @@ header nav .nav-sections .default-content-wrapper > ul > li[aria-expanded='true'
     padding: 5px;
     font-size: var(--body-font-size-s);
     margin: 0 0 0 10px;
+}
+
+header nav .nav-sections ul > li > ul > li > a {
+  display: block;
+  width: 100%;
+  height: 100%;
+  box-sizing:content-box;
+  text-decoration: none;
+  color: inherit;
 }
 
   @media (width >= 900px) {

--- a/aemedge/blocks/header/header.css
+++ b/aemedge/blocks/header/header.css
@@ -212,6 +212,11 @@ header nav .nav-sections ul > li > ul > li > a {
   color: inherit;
 }
 
+header nav a:any-link:hover {
+  color: #333;
+  text-decoration: none;
+}
+
   @media (width >= 900px) {
     header nav {
       display: flex;

--- a/aemedge/blocks/header/header.css
+++ b/aemedge/blocks/header/header.css
@@ -170,6 +170,15 @@ header nav .nav-sections ul > li {
   margin: 10px;
 }
 
+header nav .nav-sections ul > li > ul > li > a {
+  display: block;
+  width: 100%;
+  height: 100%;
+  box-sizing:content-box;
+  text-decoration: none;
+  color: inherit;
+}
+
 header nav .nav-sections .default-content-wrapper ul > li > ul {
      display: none;
      position: relative;


### PR DESCRIPTION
The navigation submenu for "We are the OCIO" was only clickable on the literal text targets rather than the entire "li" area. This expands the \<a> targets to the full width/height of the \<li> to make it easier to click and more intuitive for the user. 

Initial fix was a bit wonky on the mobile nav so needed some tweaks to play nice in both mobile/desktop widths. I believe everything is working/sized/displayed as intended now. 

Fix #256 

Test URLs:
- Before: https://main--cio-nebraska--aemdemos.aem.live/
- After: https://256-subnavtargets--cio-nebraska--aemdemos.aem.page/
